### PR TITLE
006

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,7 +18,7 @@ ignoreErrors = ["error-disable-taxonomy"]
     # Configure the home page
     [params.home]
         introHeight              = "medium"            # Input either "medium" or "large" or "fullheight"
-        showLatest               = false                    # Show latest blog post summary
+        showLatest               = true                    # Show latest blog post summary
         showAllPosts             = false                   # Set true to list all posts on home page, or set false to link to separate blog list page
         allPostsArchiveFormat    = true                    # show all posts in an archive format
         numberOfProjectsToShow   = 0                       # Maximum number of projects to show on home page. Unset or comment out to show all projects

--- a/config.toml
+++ b/config.toml
@@ -4,16 +4,15 @@ DefaultContentLanguage           = "en"                    # Default language fo
 title                            = "EKS News"
 enableEmoji = true
 enableRobotsTXT = true
-disableKinds = ["RSS", "taxonomy"]
 ignoreErrors = ["error-disable-taxonomy"]
 
 [params]
     themeStyle                   = "light"                  # Choose "light" or "dark" or "auto"
     favicon                      = "favicon.ico"          # Path to favicon file
-    showRSSButton                = false                   # Show rss button in navigation
+    showRSSButton                = true                   # Show rss button in navigation
     fadeIn                       = false                    # Turn on/off the fade-in effect
     fadeInIndex                  = false                   # Turn on/off the fade-in effect on the index page even if fade-in was otherwise turned off
-    dateFormat                   = "Jan 2, 2006"
+    dateFormat                   = "2006-01-02"
 
     # Configure the home page
     [params.home]

--- a/content/en/blog/000.md
+++ b/content/en/blog/000.md
@@ -1,3 +1,12 @@
++++
+author = "AWS Kubernetes Developer Advocates"
+categories = ["Archive", "2022"]
+date = 2022-01-07T07:00:00Z
+draft = false
+slug = "eks-news-000"
+title = "EKS News 000"
++++
+
 Welcome to the first ever issue of [EKS News](https://eks.news)! This being the very first issue, please allow me to introduce myself and the folks behind the newsletter. I'm Chris Short, among many things I'm a Kubernetes contributor, fascinated by GitOps, and a Senior Developer Advocate on the EKS team. My team of fellow developer advocates are *significant* contributors to this newsletter. I have the distinct pleasure of assembling this newsletter for you. This newsletter will evolve based on feedback we receive (hit reply, it comes to me), issues opened on [GitHub](https://github.com/chris-short/eks.news/), and any other data points we observe.
 
 On to this issue's news and other interesting things in the broader Kubernetes and Cloud Native ecosystem.
@@ -98,3 +107,5 @@ On to this issue's news and other interesting things in the broader Kubernetes a
 [Top 4 cloud native trends in 2022 shaping the future of business](https://www.cncf.io/blog/2022/01/05/top-4-cloud-native-trends-in-2022-shaping-the-future-of-business/) (CNCF Blog)
 
 [CNCF Live Webinar: Kubernetes 1.23 Release](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-live-webinar-kubernetes-123-release/) (CNCF)
+
+{{< buttondown >}}

--- a/content/en/blog/001.md
+++ b/content/en/blog/001.md
@@ -1,3 +1,12 @@
++++
+author = "AWS Kubernetes Developer Advocates"
+categories = ["Archive", "2022"]
+date = 2022-01-14T07:00:00Z
+draft = false
+slug = "eks-news-001"
+title = "EKS News 001"
++++
+
 Welcome to the second issue of EKS News! This week's newsletter contains info about using Crossplane and Flux, IPv6 EKS support, and the Cloud Native glossary.
 
 ## New and notable blogs
@@ -38,3 +47,5 @@ Welcome to the second issue of EKS News! This week's newsletter contains info ab
 * [GitOpsCon Europe](https://www.cncf.io/events/gitopscon-europe/) is a Day 0 event you can register for now as well as many others
 * Container Day information coming soon
 * Hope to see you there!
+
+{{< buttondown >}}

--- a/content/en/blog/002.md
+++ b/content/en/blog/002.md
@@ -1,3 +1,12 @@
++++
+author = "AWS Kubernetes Developer Advocates"
+categories = ["Archive", "2022"]
+date = 2022-01-21T07:00:00Z
+draft = false
+slug = "eks-news-002"
+title = "EKS News 002"
++++
+
 Hello EKS News readers! This week's newsletter contains a blog about Kubernetes service discovery using AWS Cloud Map MCS controller, Karpenter on TGIK, tracing traffic through Kubernetes, multiple [Containers from the Couch](https://containersfromthecouch.com/) episodes, and more.
 
 ## New and notable blogs
@@ -62,3 +71,5 @@ Please Subscribe to [Containers from the Couch](https://containersfromthecouch.c
 ## Because it's Friday
 
 Remember folks, [this used to be what the internet experience](https://youtu.be/ntQ48-d-8x4) was like for several years.
+
+{{< buttondown >}}

--- a/content/en/blog/003.md
+++ b/content/en/blog/003.md
@@ -1,3 +1,12 @@
++++
+author = "AWS Kubernetes Developer Advocates"
+categories = ["Archive", "2022"]
+date = 2022-01-28T07:00:00Z
+draft = false
+slug = "eks-news-003"
+title = "EKS News 003"
++++
+
 Four weeks into this newsletter and things are going well. Tooling choices have been made. The product (newsletter) is starting to hum along. Now is when it’s time to ask, “What would you like to see in the newsletter?” Hit reply and let us know.
 
 This week we’ll touch on the new Amazon VPC IPAM tool, Amazon GuardDuty for EKS, Tekton, and more! Thank you for reading, please forward this to a friend or colleague.
@@ -55,3 +64,5 @@ This week we’ll touch on the new Amazon VPC IPAM tool, Amazon GuardDuty for EK
 * Kubernetes is a cluster operating system
 * Everything in Kubernetes is a control loop
 * Some finer points: “Errors are delayed,” “all configuration is declarative,” and “how pluggable and configurable Kubernetes is.”
+
+{{< buttondown >}}

--- a/content/en/blog/004.md
+++ b/content/en/blog/004.md
@@ -1,0 +1,68 @@
++++
+author = "AWS Kubernetes Developer Advocates"
+categories = ["Archive", "2022"]
+date = 2022-02-04T07:00:00Z
+draft = false
+slug = "eks-news-004"
+title = "EKS News 004"
++++
+
+As we dig out of the snow here on the eastern half of the United States, I'm reminded how calming new fallen snow can be. There's actually a little bit of science behind it. Snow is a porous substance that can absorb noise, if the snowfall or covering is significant. Snow has all sorts of other interesting characteristics like this. You can learn more from the [National Snow & Ice Data Center](https://nsidc.org/cryosphere/snow/science/characteristics.html).
+
+This week we'll touch on CDK Pipelines, Kubernetes cluster security, and more!
+
+### New service announcements and features
+
+[What is IPAM?](https://docs.aws.amazon.com/vpc/latest/ipam/what-it-is-ipam.html)
+
+* IPAM is a VPC feature that makes it easier for you to plan, track, and monitor IP addresses for your AWS workloads.
+* TF support: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam
+
+[Introducing AWS Cloud Map MCS Controller for K8s](https://aws.amazon.com/blogs/architecture/financial-crime-discovery-using-amazon-eks-and-graph-databases/)
+
+* The controller adds a Kubernetes-native ([MCS](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api)) service discovery capability that works across Kubernetes clusters
+* With the Cloud Map MCS Controller, applications can discover and communicate with services deployed across multiple Kubernetes clusters
+* Open sourcing the solution will allow the community to adjust it to work with other service registries for on-premises use cases
+* Explains how to create a multicluster DNS service name that can be accessed within and across clusters seamlessly for things like automatic failover, and easier Kubernetes upgrades
+
+### Containers from the Couch
+
+[Kubernetes manifest management with Monokle](https://www.youtube.com/watch?v=lsMTOVJJ84o&t=266s)
+
+* An IDE-like application to help you visualize the relationship between different objects referenced in a k8s manifests, charts, and kustomize files
+* Allows you to model changes to these files before applying them to your cluster
+* Subscribe to [Containers from the Couch](https://www.youtube.com/containersfromthecouch)
+
+### New and notable blogs
+
+[Continuous Delivery of Amazon EKS Clusters Using AWS CDK and CDK Pipelines](https://aws.amazon.com/blogs/containers/continuous-delivery-of-amazon-eks-clusters-using-aws-cdk-and-cdk-pipelines/)
+
+* Explains how to use [CDK Pipelines](https://docs.aws.amazon.com/cdk/latest/guide/cdk_pipeline.html), a high-level construct library, to create a pipeline to provision and configure EKS clusters and deploy a sample application
+* Deploys an application into 2 separate clusters and uses R53 to shift the traffic between them
+
+### Ecosystem News
+
+[CNCF Archives the OpenTracing Project](https://www.cncf.io/blog/2022/01/31/cncf-archives-the-opentracing-project/)
+
+* OpenTracing is only the second project to be archived (rkt was the first)
+* Archiving OpenTracing was the project's intention following the merger of OpenTracing & OpenCensus into [OpenTelemetry](https://opentelemetry.io/)
+* You can use OpenTelemetry as an AWS service via [AWS Distro for OpenTelemetry](https://aws.amazon.com/otel/)
+
+[HOUDINI: Hundreds of Offensive and Useful Docker Images for Network Intrusion](https://houdini.secsi.io/)
+
+* Curated list of Network Security related Docker Images for Network Intrusion purposes (test your defenses thoroughly before going to prod)
+* HOUDINI is an idea of [Gaetano Perrone](https://github.com/giper45) and is developed by the same team that created [DockerSecurityPlayground](https://github.com/giper45/DockerSecurityPlayground), Security Solutions for Innovation (SecSI)
+* You can add additional tools: <https://github.com/cybersecsi/HOUDINI#add-a-tool>
+
+[Kubernetes cluster security assessment with kube-bench and kube-hunter](https://blog.flant.com/kubernetes-security-with-kube-bench-and-kube-hunter/)
+
+* How to use two powerful tools to assess your Kubernetes clusters' security posture
+* [kube-bench](https://github.com/aquasecurity/kube-bench) is a Go application that checks whether a Kubernetes cluster meets the [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes/) guidelines
+* [kube-hunter](https://github.com/aquasecurity/kube-hunter) is a Python tool designed to discover vulnerabilities in a Kubernetes cluster
+
+[AWS' Deepak Singh highlights open-source contributions, Graviton impact and the key role of startup partners](https://siliconangle.com/2022/01/26/aws-deepak-singh-highlights-open-source-contributions-graviton-impact-and-the-key-role-of-startup-partners-awsshowcases2e1/)
+
+* "Our default is to go with the open-source option, where we can open-source and it makes sense for us to do so where were feel that the broader community might benefit from it," Singh explained. "When Amazon or Netflix or Meta build something for their own needs, the first question we ask ourselves is should it be open source? Increasingly, we are all saying yes."
+* "A big part of what we're doing is to make sure that Graviton is available to you on every compute modality," Singh said. "Every high-level service that gets built on this now has the option of picking Graviton as the underlying compute infrastructure. There's never been a better time to be a developer, independent of whatever you are trying to build."
+
+{{< buttondown >}}

--- a/content/en/blog/005.md
+++ b/content/en/blog/005.md
@@ -1,0 +1,62 @@
++++
+author = "AWS Kubernetes Developer Advocates"
+categories = ["Archive", "2022"]
+date = 2022-02-11T07:00:00Z
+draft = false
+slug = "eks-news-005"
+title = "EKS News 005"
++++
+
+This week we'll touch on Amazon GuardDuty for EKS, AWS App Runner VPC Support, scaling WordPress on EKS, SIG Multicluster, and more!
+
+### New service announcements and features
+
+[Amazon GuardDuty now protects Amazon Elastic Kubernetes Service clusters](https://aws.amazon.com/about-aws/whats-new/2022/01/amazon-guardduty-elastic-kubernetes-service-clusters/)
+
+* Analyzes [Kubernetes audit logs](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) from existing and new Amazon EKS clusters in your accounts
+* Includes [27 new GuardDuty finding types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-kubernetes.html)
+* Generates a security findings that includes metadata such as pod ID, container image ID, and associated tags
+* Users now have to *opt-in* to use this feature, and the first 30 days of GuardDuty for EKS Protection are free
+
+### Containers from the Couch
+
+[AWS App Runner adds support for Amazon VPC!](https://youtu.be/7sL6BZ5t2Zg)  
+Dive into App Runner and some of the latest feature releases for the service
+
+Please, subscribe to [Containers from the Couch](https://www.youtube.com/containersfromthecouch) today!
+
+### New and notable blogs
+
+[Running WordPress on Amazon EKS with Amazon EFS Intelligent-tiering](https://aws.amazon.com/blogs/storage/running-wordpress-on-amazon-eks-with-amazon-efs-intelligent-tiering/)
+
+* By far, the most popular CMS platform today is WordPress
+* [EFS Intelligent-tiering](https://aws.amazon.com/blogs/aws/new-amazon-efs-intelligent-tiering-optimizes-costs-for-workloads-with-changing-access-patterns/) delivers automatic cost savings for workloads with changing access patterns by placing your file data in the appropriate storage class, at the right time, based on file access patterns
+* Deploying WordPress on Amazon EKS can dramatically improve the scalability and manageability of your CMS
+* Can achieve the goal of creating both a cost-optimized and performance-optimized solution for high-availability WordPress
+
+### Ecosystem News
+
+[Argo CD Deals With Our First Zero-Day CVE](https://blog.argoproj.io/argo-cd-deals-with-our-first-zero-day-cve-86e8fb158e8f)
+
+* Sharing how improved security policies helped the project respond to [CVE-2022–24348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24348)
+* On January 30, 2022, the security team at Apiiro alerted the Argo team immediately via the [responsible disclosure outlined in the Argo CD Security policy](https://github.com/argoproj/argo-cd/blob/master/SECURITY.md#reporting-a-vulnerability)
+* The Argo team released a fix within 48 hours on Feb 3 in concert with the public disclosure of the CVE and posted a [security advisory](https://github.com/argoproj/argo-cd/security/advisories/GHSA-63qx-x74g-jcr7) to Argo CD users.
+
+[Spotlight on SIG Multicluster](https://kubernetes.io/blog/2022/02/07/sig-multicluster-spotlight-2022/)
+
+* [SIG Multicluster](https://github.com/kubernetes/community/tree/master/sig-multicluster) is the SIG focused on how Kubernetes concepts are expanded and used beyond the cluster boundary.
+* In this blog, Jeremy Olmsted-Thompson, Google and Chris Short, AWS discuss the interesting problems SIG Multicluster is solving and how you can get involved.
+
+[weaveworks/tf-controller: A GitOps Terraform controller for Kubernetes](https://github.com/weaveworks/tf-controller)
+
+* TF-controller is an *experimental* controller for Flux to reconcile Terraform resources in the GitOps way
+* "At your own pace" means you don't need to GitOps-ify everything at once
+* Includes a roadmap; feel free to suggest new items
+
+[Traefik Proxy and HTTP/3 on AWS EKS](https://traefik.io/blog/traefik-proxy-and-http-3-on-aws-eks/)
+
+* An Ingress Controller is usually exposed through a LoadBalancer Service
+* Walk through how to use a NodePort Service to deploy a Network Load Balancer (NLB) in AWS and allow TCP and UDP on the same port
+* This guide shows one way to configure an Ingress Controller Traefik Proxy with the support of HTTP/3 on an EKS cluster
+
+{{< buttondown >}}

--- a/content/en/blog/006.md
+++ b/content/en/blog/006.md
@@ -1,0 +1,60 @@
++++
+author = "AWS Kubernetes Developer Advocates"
+categories = ["Archive", "2022"]
+date = 2022-02-18T07:00:00Z
+draft = false
+slug = "eks-news-006"
+title = "EKS News 006"
++++
+
+A lot of thankless work is being in the upstream Kubernetes project everyday. [There's no time like the present](https://twitter.com/rothgar/status/1493297587419451392) to acknowledge the hard work of others. This week I'd like to thank the folks working on the dockershim removal documentation for the 1.24 release. This tiger team is in charge of updating all the Kubernetes documentation with regard to Docker Engine. This often includes updates that need a deep understanding of the inner workings of Kubernetes. Thank you!
+
+This week we'll using EKS and ALBs to expose multiple applications, multi-tenacy in ArgoCD aws-load-balancer-controller and more!
+
+## New and notable blogs
+
+[How To Expose Multiple Applications on Amazon EKS Using a Single Application Load Balancer](https://aws.amazon.com/blogs/containers/how-to-expose-multiple-applications-on-amazon-eks-using-a-single-application-load-balancer/)
+
+* Every suffix (“/”) at the end of a web address will point to a different microservice... This type of load balancing or routing is known as path-based routing (routing based in the URL path).
+* Demonstrates how to expose your applications that are running as containers and being orchestrated by [Amazon EKS](https://aws.amazon.com/eks/) through an [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/application-load-balancer/)
+* [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller#readme) is a controller that helps manage Elastic Load Balancers for Kubernetes clusters
+* Different teams can be completely independent from each other because they can deploy and manage their own services and ingresses while relying on the ALB.
+
+## Ecosystem News
+
+[Best Practices for Multi-tenancy in Argo CD](https://blog.argoproj.io/best-practices-for-multi-tenancy-in-argo-cd-273e25a047b0)
+
+* Argo CD supports RBAC and SSO which allows admins to specify and scope permissions based on user or role
+* Today, there are two choices when using Argo CD with untrusted users:
+
+1. Admins can carefully control the contents of connected git repositories via permissions in git and set limitations on which repositories can be added to Argo CD.
+1. Each set of users can operate on independent instances of Argo CD. Either approach will prevent users from accessing secrets or components that are beyond their expected scope.
+
+[Auto Scaling CI Agents At Wix](https://www.wix.engineering/post/auto-scaling-ci-agents-at-wix)
+
+Our summary is a direct quote of some of their summary:
+
+* Identified bottlenecks and missing features on our legacy architecture.
+* Redesigned the Infrastructure to enable scale & configurability.
+* Used awesome open source projects in order to implement generic automated scaling: K8S, KEDA and Prometheus.
+* Designed a monitoring solution in order to make the right decisions and be cost-effective.
+
+[PredictKube - an AI-based predictive autoscaler for KEDA made by Dysnix](https://keda.sh/blog/2022-02-09-predictkube-scaler/)
+
+* Dysnix has built [PredictKube](https://predictkube.com/), a KEDA-based scaler that is responsible for resource balancing  * AI model that has learned to react proactively to patterns of traffic activity
+* Help with both in-time scaling and solving the problem of overprovision
+
+[kubernetes-sigs/aws-load-balancer-controller: A Kubernetes controller for Elastic Load Balancers](https://github.com/kubernetes-sigs/aws-load-balancer-controller)
+
+* Just updated! Now uses the new Ingress API version networking.k8s.io/v1 available in kubernetes 1.19 and later releases
+* **IMPORTANT** If you are upgrading the controller from a prior version to v2.4.0, please apply the entire manifest or use helm due to the webhook changes.
+* It satisfies Kubernetes [Ingress resources](https://kubernetes.io/docs/concepts/services-networking/ingress/) by provisioning [Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html)
+* It satisfies Kubernetes [Service resources](https://kubernetes.io/docs/concepts/services-networking/service/) by provisioning [Network Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html)
+
+## Roadmaps
+
+[GitHub - Amazon Managed Grafana Roadmap](https://github.com/aws/amazon-managed-grafana-roadmap)
+
+[GitHub - Amazon Mananaged Prometheus Roadmap](https://github.com/aws/amazon-managed-service-for-prometheus-roadmap)
+
+{{< buttondown >}}

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Archives"
+date: 2022-02-18T08:04:39-05:00
+draft: false
+---
+
+Every issue of EKS News can be found here.


### PR DESCRIPTION
<!-- Please keep this note for the community -->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!-- Thank you for keeping this note for the community -->

<!--

**Security disclosures**

If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).

-->

*Issue #, if available:*
N/A

*Description of changes:*
Adding the archives to the web site directly. Will need to disable on Buttondown and get folks over to the site. Having the archives on the site will help with SEO and keep everything EKS News related in one place (minus the mail sending piece).

TODO: Figure out what to do with `/blog/` because that's not a good directory name. Spelunking of Hugo Theme will be needed. But, this shouldn't be a blocker as we can put in 301 redirects in `./public/_redirect`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
