### PR TITLE
Using aliases instead of the _redirects

### DIFF
--- a/content/en/archives/_index.md
+++ b/content/en/archives/_index.md
@@ -2,6 +2,9 @@
 title: "Archives"
 draft: false
 slug: archives
+aliases:
+    - /archive
+    - /blog
 ---
 
 Every issue of EKS News can be found here.

--- a/public/_redirect
+++ b/public/_redirect
@@ -1,5 +1,0 @@
-archive/ /archives 301
-blog/ /archives 301
-/archive/eks-news-*/ /archives/:splat 301
-archive/eks-news-*/ /archives/:splat 301
-blog/eks-news-* /archives/:splat 301


### PR DESCRIPTION
<!-- Please keep this note for the community -->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!-- Thank you for keeping this note for the community -->

<!--

**Security disclosures**

If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).

-->

*Issue #, if available:*

*Description of changes:*

Adding aliases to the archives page since the Netlify redirects file isn't working as expected
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
