### PR TITLE
Does /latest work as an alias?

### DIFF
--- a/content/en/archives/008.md
+++ b/content/en/archives/008.md
@@ -7,7 +7,7 @@ slug = "008"
 title = "EKS News 008"
 aliases = [
     "/archive/eks-news-008",
-    "thisweek"
+    "/thisweek"
 ]
 +++
 

--- a/content/en/archives/008.md
+++ b/content/en/archives/008.md
@@ -7,7 +7,6 @@ slug = "008"
 title = "EKS News 008"
 aliases = [
     "/archive/eks-news-008",
-    "/thisweek",
     "/latest"
 ]
 +++

--- a/content/en/archives/008.md
+++ b/content/en/archives/008.md
@@ -6,7 +6,8 @@ draft = false
 slug = "008"
 title = "EKS News 008"
 aliases = [
-    "/archive/eks-news-008"
+    "/archive/eks-news-008",
+    "latest"
 ]
 +++
 

--- a/content/en/archives/008.md
+++ b/content/en/archives/008.md
@@ -7,7 +7,8 @@ slug = "008"
 title = "EKS News 008"
 aliases = [
     "/archive/eks-news-008",
-    "/thisweek"
+    "/thisweek",
+    "/latest"
 ]
 +++
 

--- a/content/en/archives/008.md
+++ b/content/en/archives/008.md
@@ -7,7 +7,7 @@ slug = "008"
 title = "EKS News 008"
 aliases = [
     "/archive/eks-news-008",
-    "latest"
+    "thisweek"
 ]
 +++
 


### PR DESCRIPTION
"latest" is the most generic alias possible. Let's see if this works.

<!-- Please keep this note for the community -->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!-- Thank you for keeping this note for the community -->

<!--

**Security disclosures**

If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).

-->

*Issue #, if available:*
N/A

*Description of changes:*
I would love to have an alias that I can point to in emails for the latest issue. This is to cover not having to change the "view this online" every week. For DevOps'ish, I actually update a shortened link every week for a few things. That's another option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
